### PR TITLE
perf: lazy-load Calendly widget, remove unused react-calendly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,7 @@
       "dependencies": {
         "@glidejs/glide": "^3.6.2",
         "boxicons": "^2.1.4",
-        "caniuse-lite": "^1.0.30001782",
-        "react-calendly": "^4.4.0"
+        "caniuse-lite": "^1.0.30001782"
       },
       "devDependencies": {
         "@fullhuman/postcss-purgecss": "^8.0.0",
@@ -5043,33 +5042,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-calendly": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/react-calendly/-/react-calendly-4.4.0.tgz",
-      "integrity": "sha512-kMd8fEby0plL5aCebhjq9aesOJ6YWcmR3Pjs3bufncykrp7b6TryaCnWGoq4xZc/oipyudAVCIRgPVUjUEr8nQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8",
-        "npm": ">=5"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "scheduler": "^0.27.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.3"
-      }
-    },
     "node_modules/react-interactive": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-interactive/-/react-interactive-0.8.3.tgz",
@@ -5313,13 +5285,6 @@
       "engines": {
         "node": ">=v12.22.7"
       }
-    },
-    "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@glidejs/glide": "^3.6.2",
     "boxicons": "^2.1.4",
-    "caniuse-lite": "^1.0.30001782",
-    "react-calendly": "^4.4.0"
+    "caniuse-lite": "^1.0.30001782"
   }
 }

--- a/src/js/contact.js
+++ b/src/js/contact.js
@@ -41,28 +41,36 @@ function updateStatusRealtime() {
 updateStatusRealtime();
 setInterval(updateStatusRealtime, 15000);
 
-// Calendly Widget
-function calendlyWidget() {
-  const calendlyContainer = document.getElementById('calendly-widget');
-  if (calendlyContainer) {
-    // Create Calendly inline widget
-    const calendlyDiv = document.createElement('div');
-    calendlyDiv.className = 'calendly-inline-widget';
-    calendlyDiv.setAttribute('data-url', 'https://calendly.com/swietonautomotive/service');
-    calendlyDiv.style.minWidth = '320px';
-    calendlyDiv.style.height = '700px';
-    
-    // Add the widget to the container
-    calendlyContainer.appendChild(calendlyDiv);
-    
-    // Load Calendly script
-    const script = document.createElement('script');
-    script.type = 'text/javascript';
-    script.src = 'https://assets.calendly.com/assets/external/widget.js';
-    script.async = true;
-    document.head.appendChild(script);
-  }
+// Calendly Widget — lazy-loaded only when user scrolls near the section
+function loadCalendlyWidget(container) {
+  const calendlyDiv = document.createElement('div');
+  calendlyDiv.className = 'calendly-inline-widget';
+  calendlyDiv.setAttribute('data-url', 'https://calendly.com/swietonautomotive/service');
+  calendlyDiv.style.minWidth = '320px';
+  calendlyDiv.style.height = '700px';
+  container.appendChild(calendlyDiv);
+
+  const script = document.createElement('script');
+  script.type = 'text/javascript';
+  script.src = 'https://assets.calendly.com/assets/external/widget.js';
+  script.async = true;
+  document.head.appendChild(script);
 }
 
-// Initialize Calendly widget when DOM is loaded
-document.addEventListener('DOMContentLoaded', calendlyWidget);
+function initCalendlyObserver() {
+  const container = document.getElementById('calendly-widget');
+  if (!container) return;
+
+  const observer = new IntersectionObserver(
+    (entries, obs) => {
+      if (entries[0].isIntersecting) {
+        obs.disconnect();
+        loadCalendlyWidget(container);
+      }
+    },
+    { rootMargin: '200px' }
+  );
+  observer.observe(container);
+}
+
+document.addEventListener('DOMContentLoaded', initCalendlyObserver);


### PR DESCRIPTION
## Summary

- **Lazy-load Calendly via IntersectionObserver** — Calendly's external `widget.js` (~1.1 MB, bundles its own React) was loading on every page load via `DOMContentLoaded`, blocking the main thread and contributing to high Total Blocking Time (1,440ms). Now loads only when the user scrolls within 200px of the booking section. Users who never reach the contact section pay zero cost.
- **Remove `react-calendly`** — was listed as a dependency but never imported anywhere in the codebase.

## Problem

```js
// Before — loads 1.1 MB Calendly bundle on every page load
document.addEventListener('DOMContentLoaded', calendlyWidget);
```

## Solution

```js
// After — loads only when user scrolls near the contact section
const observer = new IntersectionObserver(
  (entries, obs) => {
    if (entries[0].isIntersecting) {
      obs.disconnect();
      loadCalendlyWidget(container);
    }
  },
  { rootMargin: '200px' }
);
observer.observe(container);
```

## Test plan

- [x] All 44 unit tests pass
- [x] Production build verified clean
- [x] Calendly widget still loads and functions correctly when scrolling to contact section
- [ ] Run PageSpeed Insights after deploy to confirm TBT improvement

https://claude.ai/code/session_01Ku4QJXrgGBX16e2eDRM1S3