### PR TITLE
fix: use FTPS protocol for Hostinger FTP deploy

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,10 @@ jobs:
       - name: Deploy to Hostinger via FTP
         uses: SamKirkland/FTP-Deploy-Action@v4.3.5
         with:
-          server: ${{ secrets.HOSTINGER_FTP_SERVER }} 
+          server: ${{ secrets.HOSTINGER_FTP_SERVER }}
           username: ${{ secrets.HOSTINGER_FTP_USERNAME }}
           password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
           local-dir: dist/
           server-dir: /public_html/
+          protocol: ftps
+          port: 21


### PR DESCRIPTION
Hostinger requires FTPS (FTP over TLS) rather than plain FTP.
Adding protocol: ftps and explicit port: 21 resolves the control
socket timeout error during deployment.

https://claude.ai/code/session_01B2p5GAFBMdnygBaidfEFY2