### PR TITLE
Fix preloader not hiding when DOM is already loaded

### DIFF
--- a/src/js/hidepreloader.js
+++ b/src/js/hidepreloader.js
@@ -1,11 +1,17 @@
 // Hide Preloader ------------
 const preloader = document.getElementById("loader-wrapper");
 
-document.addEventListener("DOMContentLoaded", function () {
+function hidePreloader() {
   if (preloader) preloader.classList.add("hide-preloader");
 
   setTimeout(function () {
     if (preloader) preloader.hidden = true;
     if (preloader) preloader.style.display = "none";
   }, 600);
-});
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", hidePreloader);
+} else {
+  hidePreloader();
+}


### PR DESCRIPTION
The hidepreloader module was only attaching an event listener for
DOMContentLoaded, which had already fired by the time the module script ran
(since it's at the end of the HTML). This caused the loading screen to never
disappear.

Now the code checks document.readyState and calls hidePreloader immediately
if the DOM is already loaded, fixing the issue while maintaining compatibility
with tests that manually dispatch the DOMContentLoaded event.

https://claude.ai/code/session_013GoMrmNTWL2Ywjr4wcp5YB