### PR TITLE
Fix Hostinger loading freeze by ensuring preloader hides even if carousel init fails

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+// Utilities - must be imported first to ensure preloader hides even if other modules fail
+import "./js/hidepreloader.js"
+
 // Page sections
 import "./js/header.js"
 import "./js/deals.js"
@@ -6,8 +9,5 @@ import "./js/testimonials.js"
 import "./js/contact.js"
 import "./js/footer.js"
 
-// Third-party libraries
+// Third-party libraries - wrapped with error handling
 import "./js/glide.js"
-
-// Utilities
-import "./js/hidepreloader.js"

--- a/src/js/glide.js
+++ b/src/js/glide.js
@@ -3,49 +3,64 @@ import Glide from "@glidejs/glide";
 import "@glidejs/glide/dist/css/glide.core.min.css";
 import "@glidejs/glide/dist/css/glide.theme.min.css";
 
-new Glide(".glide-deals", {
-  type: "carousel",
-  perView: 3,
-  swipeThreshold: 40,
-  dragThreshold: 60,
-  animationDuration: 250,
-  peek: 40,
-  breakpoints: {
-    992: {
-      perView: 1,
-    },
-  },
-}).mount();
+function initializeCarousels() {
+  try {
+    if (document.querySelector(".glide-deals")) {
+      new Glide(".glide-deals", {
+        type: "carousel",
+        perView: 3,
+        swipeThreshold: 40,
+        dragThreshold: 60,
+        animationDuration: 250,
+        peek: 40,
+        breakpoints: {
+          992: {
+            perView: 1,
+          },
+        },
+      }).mount();
+    }
 
-new Glide(".glide-services", {
-  type: "carousel",
-  perView: 3,
-  swipeThreshold: 40,
-  dragThreshold: 60,
-  animationDuration: 250,
-  peek: 40,
-  breakpoints: {
-    // 992: {
-    //   perView: 1,
-    // },
-    768: {
-      perView: 1,
-    },
-  },
-}).mount();
+    if (document.querySelector(".glide-services")) {
+      new Glide(".glide-services", {
+        type: "carousel",
+        perView: 3,
+        swipeThreshold: 40,
+        dragThreshold: 60,
+        animationDuration: 250,
+        peek: 40,
+        breakpoints: {
+          768: {
+            perView: 1,
+          },
+        },
+      }).mount();
+    }
 
-new Glide(".glide-reviews", {
-  type: "carousel",
-  perView: 3,
-  swipeThreshold: 40,
-  dragThreshold: 60,
-  animationDuration: 250,
-  breakpoints: {
-    992: {
-      perView: 2,
-    },
-    768: {
-      perView: 1,
-    },
-  },
-}).mount();
+    if (document.querySelector(".glide-reviews")) {
+      new Glide(".glide-reviews", {
+        type: "carousel",
+        perView: 3,
+        swipeThreshold: 40,
+        dragThreshold: 60,
+        animationDuration: 250,
+        breakpoints: {
+          992: {
+            perView: 2,
+          },
+          768: {
+            perView: 1,
+          },
+        },
+      }).mount();
+    }
+  } catch (error) {
+    console.error("Error initializing Glide carousels:", error);
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initializeCarousels);
+} else {
+  initializeCarousels();
+}


### PR DESCRIPTION
- Move hidepreloader.js import to top to guarantee it executes first
- Wrap Glide carousel initialization in DOMContentLoaded listener with error handling
- Prevents preloader from staying visible if carousel module throws errors
- Ensures carousel elements exist before attempting initialization

https://claude.ai/code/session_011KKuFc9SaajXnsrfWgD4vZ