### PR TITLE
Remove loading screen from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,6 @@
   <link rel="dns-prefetch" href="https://assets.calendly.com">
 
   <!-- Stylesheets -->
-  <link rel="stylesheet" href="./src/css/preloader.min.css" type="text/css">
   <link rel="stylesheet" href="./src/css/bs-compiled.css" type="text/css">
   <link rel="stylesheet" href="./src/css/style.css" type="text/css">
   <link rel="stylesheet" href="./src/css/boxicons-subset.css" type="text/css">
@@ -88,27 +87,6 @@
 </head>
 
 <body itemtype="https://schema.org/WebPage" itemscope="itemscope" class="carclub">
-
-  <div id="loader-wrapper">
-    <div class="loader">
-      <div class="line"></div>
-      <div class="line"></div>
-      <div class="line"></div>
-      <div class="line"></div>
-      <div class="line"></div>
-      <div class="line"></div>
-      <div class="subline"></div>
-      <div class="subline"></div>
-      <div class="subline"></div>
-      <div class="subline"></div>
-      <div class="subline"></div>
-      <div class="loader-circle-1">
-        <div class="loader-circle-2"></div>
-      </div>
-      <div class="needle"></div>
-      <div class="loading">Loading</div>
-    </div>
-  </div>
 
   <header id="header" class="site-header">
     <div class="container">

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,3 @@
-// Utilities - must be imported first to ensure preloader hides even if other modules fail
-import "./js/hidepreloader.js"
-
 // Page sections
 import "./js/header.js"
 import "./js/deals.js"


### PR DESCRIPTION
- Remove #loader-wrapper div and speedometer loading animation from index.html
- Remove preloader.min.css stylesheet reference
- Loading screen will no longer appear when users visit the site

https://claude.ai/code/session_01MzN4ZUGmToyAXfJYz38CUP