### PR TITLE
Remove outdated vite-plugin-javascript-obfuscator dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "postcss": "^8.5.8",
     "sass": "^1.98.0",
     "vite": "^7.1.3",
-    "vite-plugin-javascript-obfuscator": "^3.1.0",
     "vite-plugin-minify": "^2.1.0",
     "vite-plugin-webfont-dl": "^3.12.0",
     "vitest": "^3.2.4"


### PR DESCRIPTION
The plugin was not in use in vite.config.js and hasn't been updated since 2022,
making it incompatible with Vite 8. Code minification will continue to be handled
by Terser, which is already configured in the build options.

https://claude.ai/code/session_01DcoouD7dESqWmvgsZRyUba