### PR TITLE
Update actions/checkout to @v4 for cleaner dependency management

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4.0.2


### PR DESCRIPTION
Use @v4 instead of pinned patch version @v4.1.7 to automatically receive patch fixes.

https://claude.ai/code/session_01Ra1cSxpHEj7ZZD62v25HHu